### PR TITLE
Add openssl as a requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
     version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9               # [win and py27]
     - vc10              # [win and py34]
@@ -31,6 +31,7 @@ requirements:
     - vc   9   # [win and py27]
     - vc  10   # [win and py34]
     - vc  14   # [win and py35]
+    - openssl 1.0.*
 
 test:
   commands:


### PR DESCRIPTION
Had a few errors on new installs with `gdal`. Turns out `libpq` links to `openssl` and this has been missing as a prereq.
